### PR TITLE
Modify upload command so that can upload files only in local

### DIFF
--- a/src/lib/command.coffee
+++ b/src/lib/command.coffee
@@ -78,8 +78,10 @@ exports.run = ()->
     )
     .option(
       '-F, --force'
-      ,"If does not exist source in config.json but exist on server,
-       server's file will be deleted"
+      ,"If does not exist source in gas-project.json but exist on server,
+       server's file will be deleted.
+       And if does not exist source on server but in gas-project.json,
+       upload the new file to server"
       )
     .action(require('./commands/upload-command').upload)
 


### PR DESCRIPTION
i'm sorry that i've written the message in Japanese

既存のプロジェクトに新規ファイルを `upload` コマンドで追加できるようにしてみました。
既に新規ファイルがローカルに存在し、`gas-project.json` にもそのファイルの記述がある場合、
```shell
$ gas upload -e mylib --force
```
でその新規ファイルも追加でアップロードされるようにしてみました。

pull request も coffee script も初めてなので、何か不備があるかもしれませんが、その際は優しくご指摘くださいませ。