### PR TITLE
Add supporting cli of creating new project as gas create

### DIFF
--- a/src/lib/command.coffee
+++ b/src/lib/command.coffee
@@ -84,6 +84,32 @@ exports.run = ()->
     .action(require('./commands/upload-command').upload)
 
   program
+    .command("create")
+    .description("create a new google apps script project")
+    .option(
+      '-e, --encoding <encoding>'
+      ,"The encoding of reading file", "UTF-8"
+    )
+    .option(
+      '-S, --src "<to:from...>"'
+      ,"""\n\tThe source mapping between project file and local file.
+      \tPlease set like below.
+      \t  --src "code:./src/code.js index:./src/index.html"
+      \tThis option is preferred all other options and setting file.
+
+      """
+      ,(value)->
+        return value.split(" ").reduce((map, source)->
+          m = source.split(":")
+          map[m[0]] =
+            path : m[1]
+            type : if path.extname(m[1]) == ".html" then "html" else "server_js"
+          return map
+        ,{})
+    )
+    .action(require('./commands/create-command').create)
+
+  program
     .command("init")
     .description("generate config file.")
     .option(

--- a/src/lib/commands/create-command.coffee
+++ b/src/lib/commands/create-command.coffee
@@ -1,0 +1,63 @@
+###
+
+gas-manager
+https://github.com/soundTricker/gas-manager
+
+Copyright (c) 2013 Keisuke Oohashi
+Licensed under the MIT license.
+
+###
+
+'use strict'
+
+
+fs = require 'fs'
+path = require 'path'
+async = require 'async'
+Manager = require('../gas-manager').Manager
+util = require './util'
+
+
+exports.create = (options)->
+  program = @
+  config = util.loadConfig(program)
+
+  manager = new Manager(config)
+
+  if options.src
+    config[program.env] =
+      files : options.src
+
+  if !config[program.env]?.files
+    throw new Error(
+      "There is no [#{program.env}] enviroment setting at config file"
+    )
+
+  project = manager.createProject program.env
+  async.waterfall([
+    (cb)->
+      async.parallel(
+        do (tasks = []) ->
+          for name,file of config[program.env].files
+            tasks.push(
+              do (name = name, file = file) ->
+                (callback)->
+                  fs.readFile(path.resolve(file.path)
+                    ,encoding : options.encoding
+                    ,(err, source)->
+                      return callback(err) if err
+                      project.addFile name, file.type, source
+                      callback(null)
+                  )
+            )
+          tasks
+        ,(err)->
+          throw err if err
+          cb(null, project)
+      )
+    (project,cb)->
+      project.deploy(cb)
+  ],(err, project)->
+    throw err if err
+    console.log "Success creating for #{project.filename}; fileId: #{project.fileId}"
+  )


### PR DESCRIPTION
gas-project.json に `fileId` 抜きで指定しておいて
```json:gas-project.json
{
  ...
  "pink": {
    "__fileId": "",
    "files": {
      "index": {
        "path": "/path/to/project/index.html",
        "type": "html"
      },
      "front": {
        "path": "/path/to/project/front.js",
        "type": "server_js"
      }
    }
  },
  ...
}
```

次のように実行すると、

```shell
$ gas create -e pink
Success creating for pink; fileId: 1uxxxxyyyyyyyyyyyyzzzzzzzz
```
プロジェクトが作られて、`fileId` が表示されるようにしてみました。この `fileId` を gas-project.json に書き込む想定です。